### PR TITLE
Make pbr deal with namespaced packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,10 @@ setup-hooks =
 [files]
 packages =
     talons
+    talons.auth
+namespace_packages =
+    talons
+    talons.auth
 
 [pbr]
 skip_changelog = true

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@
 import setuptools
 
 setuptools.setup(
-    setup_requires=['d2to1>=0.2.10,<0.3', 'pbr>=0.5,<0.6'],
-    d2to1=True,
-    namespace_packages=['talons', 'talons.auth'],
+    setup_requires=['d2to1>=0.2.10,<0.3', 'pbr>=0.5.23,<0.6'],
+    d2to1=True
 )

--- a/talons/__init__.py
+++ b/talons/__init__.py
@@ -1,1 +1,2 @@
-__import__("pkg_resources").declare_namespace(__name__)
+from pkg_resources import declare_namespace
+declare_namespace(__name__)

--- a/talons/auth/__init__.py
+++ b/talons/auth/__init__.py
@@ -1,1 +1,2 @@
-__import__("pkg_resources").declare_namespace(__name__)
+from pkg_resources import declare_namespace
+declare_namespace(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 setenv = 
     VIRTUAL_ENV = {envdir}
-    PROCESSION_TEST = 1
 commands =
    python setup.py testr --slowest --testr-args='--concurrency=1 {posargs}'
 sitepackages = False


### PR DESCRIPTION
pbr >= 0.5.23 handles namespaced packages properly, so
remove them from the setup.py and place into setup.cfg,
which is used by pbr when constructing eggs. This has the
additional benefit of allowing coverage to work as well.
