### PR TITLE
Remove faulty topic from setup.cfg and remove pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   - TOX_ENV=py26
   - TOX_ENV=py27
   - TOX_ENV=py33
-  - TOX_ENV=pypy
   - TOX_ENV=pep8
 
 script: tox -e $TOX_ENV

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifier =
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 2.6
     Programming Language :: Python :: 3.3
-    Topic :: System :: Developer Tools
 keywords =
     falcon
     middleware


### PR DESCRIPTION
The Travis PyPy builder is experiencing issues, so removing it
from the .travis.yml file for now. Also, after running
python setup.py register, turns out there was a bad topic in the
list of trove classifications, so removed that.
