### PR TITLE
Allow Authenticates plugins to set roles/groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,18 +158,31 @@ Talons comes with a few simple examples of Authenticator plugins.
 
 ### `talons.auth.external.Authenticator`
 
-A generic Authenticator plugin that has a single configuration option,
+A generic Authenticator plugin that has one main configuration option,
 `authenticate_external_authfn` which should be the "module.function" or
 "module.class.method" dotted-import notation for a function or class
 method that accepts a single parameter. This function will be called by
 the instance of `talons.auth.authenticate.external.Authenticator` to
 validate the credentials of a request.
 
+In addition, there are two other configuration options that indicate
+whether the `external_authfn` function may set the roles or groups
+attributes on the supplied identity:
+
+ * `external_sets_roles`: Boolean (defaults to False). A True value
+   indicates the plugin may set the roles attribute on the identity
+   object.
+
+ * `external_sets_groups`: Boolean (defaults to False). A True value
+   indicates the plugin may set the groups attribute on the identity
+   object.
+
 #### Example
 
 Suppose we have some application code that looks up a stored password
 for a user in a [`Redis`](http://redis.io) Key-Value Store. Salted, encrypted
-passwords for each user are stored in the Redis KVS.
+passwords for each user are stored in the Redis KVS, along with a
+comma-separated list of roles the user belongs to.
 
 Our application has a Python file called `/application/auth.py` that looks
 like this:
@@ -195,10 +208,16 @@ def authenticate(identity):
     user = identity.login
     pass = identity.key
 
-    stored_pass = _AUTH_DB.get(user)
-    if stored_pass:
-        return _pass_matches_stored_pass(pass, stored_pass)
-    return False
+    # Assume that user "records" are stored in Redid in the following format:
+    # salt:hashedpass#roles
+    # Where roles is a comma-separated list of roles
+    user_record = _AUTH_DB.get(user)
+    if user_record:
+        stored_pass, role_list = user_record.split('#')
+        auth_success = _pass_matches_stored_pass(pass, stored_pass)
+        if auth_success:
+            identity.roles = role_list.split(',')
+    return auth_success
 ```
 
 To use the above `application.auth.authenticate` method for authenticating
@@ -206,6 +225,7 @@ identities, we'd supply the following configuration options to the
 `talons.auth.external.Authenticator` constructor:
 
  * `external_authfn=application.auth.authenticate`
+ * `external_sets_roles=True`
 
 ### `talons.auth.htpasswd.Authenticator`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,6 @@ setup-hooks =
     pbr.hooks.setup_hook
 
 [files]
-packages =
-    talons
-    talons.auth
 namespace_packages =
     talons
     talons.auth

--- a/talons/auth/external.py
+++ b/talons/auth/external.py
@@ -42,7 +42,13 @@ class Authenticator(interfaces.Authenticates):
                              or module.function that will be used
                              to authenticate. This function will
                              accept as its only argument the
-                             `talons.interfaces.Identity` object.
+                             `talons.interfaces.auth.Identity` object.
+            external_sets_roles: Boolean (defaults to False) of whether the
+                                 external authentication function will set the
+                                 roles attribute of the Identity object.
+            external_sets_groups: Boolean (defaults to False) of whether the
+                                  external authentication function will set
+                                  the groups attribute of the Identity object.
 
         :raises `talons.exc.BadConfiguration` if configuration options
                 are not valid or conflict with each other.
@@ -72,9 +78,26 @@ class Authenticator(interfaces.Authenticates):
             LOG.error(msg)
             raise exc.BadConfiguration(msg)
 
+        self.sets_roles = conf.get('external_sets_roles', False)
+        self.sets_groups = conf.get('external_sets_groups', False)
+
     def authenticate(self, identity):
         """
         Looks at the supplied identity object and returns True if the
         credentials can be verified, False otherwise.
         """
         return self.authfn(identity)
+
+    def sets_roles(self):
+        """
+        Returns True if the authenticator plugin decorates the Identity
+        object with a set of roles, False otherwise.
+        """
+        return self.sets_roles
+
+    def sets_groups(self):
+        """
+        Returns True if the authenticator plugin decorates the Identity
+        object with a set of groups, False otherwise.
+        """
+        return self.sets_groups

--- a/talons/auth/interfaces.py
+++ b/talons/auth/interfaces.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright 2013 Jay Pipes
+# Copyright 2013-2014 Jay Pipes
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -84,6 +84,22 @@ class Authenticates(object):
     def authenticate(self, identity):
         """
         Looks at the supplied identity object and returns True if the
-        credentials can be verified, False otherwise.
+        credentials can be verified, False otherwise. If the plugin also
+        retrieves role or group information, it may modify the supplied
+        Identity object.
         """
         raise NotImplementedError  # pragma: NO COVER
+
+    def sets_roles(self):
+        """
+        Returns True if the authenticator plugin decorates the Identity
+        object with a set of roles, False otherwise.
+        """
+        return False
+
+    def sets_groups(self):
+        """
+        Returns True if the authenticator plugin decorates the Identity
+        object with a set of groups, False otherwise.
+        """
+        return False


### PR DESCRIPTION
Makes a change to talons.auth.interfaces.Authenticates that
allows a plugin to modify the supplied talons.auth.interfaces.Identity
object and set roles and groups attributes. Two discovery methods are
added to the Authenticates plug for "downstream" callers to use
in determining if a plugin is able to set either roles or groups
on an identity.

Documentation for an external authenticator that sets the roles
attribute is also included.

Addresses Issue #10
