### PR TITLE
Increase version to 0.2 and put back packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = talons
-version = 0.1
+version = 0.2
 summary = Hooks for Falcon
 description-file = README.md
 author = Jay Pipes
@@ -26,6 +26,9 @@ setup-hooks =
     pbr.hooks.setup_hook
 
 [files]
+packages =
+    talons
+    talons.auth
 namespace_packages =
     talons
     talons.auth


### PR DESCRIPTION
Travis builder is failing for some reason, and I want to check
that it's not because I removed packages = from the setup.cfg
file...

Also, bumped version in setup.cfg to 0.2 since that is the next
version of Talons we're targeting right now.
