### PR TITLE
Fix talons.helpers.import_function always returning None

### DIFF
--- a/talons/helpers.py
+++ b/talons/helpers.py
@@ -48,3 +48,4 @@ def import_function(import_str):
         err_details = traceback.format_exception(*sys.exc_info())
         LOG.error(msg + ' Details: (%s)'.format(err_details))
         raise
+    return fn

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -34,3 +34,7 @@ class TestHelpers(base.TestCase):
     def test_not_callable(self):
         with testtools.ExpectedException(TypeError):
             helpers.import_function('sys.stdout')
+
+    def test_return_function(self):
+        fn = helpers.import_function('os.path.join')
+        self.assertEqual(callable(fn), True)


### PR DESCRIPTION
In talons.helpers.import_function, the found function is not returned
and it returns None instead, causing TypeError when external.Authenticator
is used.
