### PR TITLE
Adds start of Authorization plugin framework

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Jay Pipes <jaypipes@gmail.com>
+Sebastián Magrí <sebasmagri@gmail.com>

--- a/README.md
+++ b/README.md
@@ -235,6 +235,19 @@ the credentials of a request. The plugin has a single configuration option:
  * `htpasswd_path`: The filepath to the Apache htpasswd file to
    use for authentication checks.
 
+## Authorizers
+
+Each class that derives from `talons.auth.interfaces.Authorizes` is
+called an "Authorizer". Each Authorizer implements a single method,
+`authorize()`, that takes a `talons.auth.interfaces.Identity` object,
+a `talons.auth.interfaces.ResourceAction` object.
+
+At present, there is only a single Authorizer built in to Talons: the
+`talons.auth.external.Authorizer` class. Like its sister, the
+`talons.auth.external.Authenticator`, it accepts an external callable that
+accepts the identity and resource action parameters and returns whether
+the identity is allowed to perform the action on the resource.
+
 Why `talons.auth`?
 ==================
 

--- a/tests/auth/test_external.py
+++ b/tests/auth/test_external.py
@@ -62,3 +62,5 @@ class TestExternal(base.TestCase):
             conf = dict(external_authfn='authme')
             auth = external.Authenticator(**conf)
             self.assertEquals('this', auth.authenticate('this'))
+            self.assertFalse(auth.sets_roles())
+            self.assertFalse(auth.sets_groups())

--- a/tests/auth/test_resource_action.py
+++ b/tests/auth/test_resource_action.py
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright 2014 Jay Pipes
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from falcon import api
+from falcon import testing as ftesting
+
+from talons.auth import interfaces
+
+from tests import base
+
+
+class AppResource(object):
+
+    def on_get(self, req, resp, user_id, **kwargs):
+        resp.status = 200
+        resp.body = user_id
+
+
+class TestResource(base.TestCase):
+
+    def setUp(self):
+        self.resp_mock = ftesting.StartResponseMock()
+        super(TestResource, self).setUp()
+
+    def make_request(self, path, **kwargs):
+        return self.app(ftesting.create_environ(path=path, **kwargs),
+                        self.resp_mock)
+
+    def test_dotted_notation(self):
+
+        def hook(req, resp, params):
+            self.res = interfaces.ResourceAction(req, params)
+            hook.called = True
+
+        hook.called = False
+
+        app = api.API(before=[hook])
+        app.add_route("/users/{user_id}", AppResource())
+        self.app = app
+
+        self.make_request('/users/123', method='GET')
+        self.assertTrue(hook.called)
+        res_dotted = self.res.to_string()
+        self.assertEquals('users.123.get', res_dotted)
+
+        hook.called = False
+
+        self.make_request('/users/123?q=23491', method='GET')
+        self.assertTrue(hook.called)
+        res_dotted = self.res.to_string()
+        self.assertEquals('users.123.get', res_dotted)

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,7 +17,10 @@
 import logging
 
 import fixtures
+import mock
 import testtools
+
+LOG_FORMAT = "[%(levelname)-7s] %(msg)s"
 
 
 class TestCase(testtools.TestCase):
@@ -27,5 +30,25 @@ class TestCase(testtools.TestCase):
     """
 
     def setUp(self):
-        self.useFixture(fixtures.FakeLogger(level=logging.DEBUG))
+        self.useFixture(fixtures.FakeLogger(level=logging.DEBUG,
+                                            format=LOG_FORMAT))
         super(TestCase, self).setUp()
+
+    def patch(self, target, *args, **kwargs):
+        """
+        Returns a started `mock.patch` object for the supplied target.
+
+        The caller may then call the returned patcher to create a mock object.
+
+        The caller does not need to call stop() on the returned
+        patcher object, as this method automatically adds a cleanup
+        to the test class to stop the patcher.
+
+        :param target: String module.class or module.object expression to patch
+        :param **kwargs: Passed as-is to `mock.patch`. See mock documentation
+                         for details.
+        """
+        p = mock.patch(target, *args, **kwargs)
+        m = p.start()
+        self.addCleanup(p.stop)
+        return m


### PR DESCRIPTION
This patch adds a new interface, `talons.auth.interfaces.Authorizes`
which serves as the basis for the planned authorization plugin
framework.
