### PR TITLE
fix travis test run by using tox==1.6.1 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-install: pip install tox --use-mirrors
+install: pip install tox==1.6.1 --use-mirrors
 env:
   - TOX_ENV=py26
   - TOX_ENV=py27


### PR DESCRIPTION
Due to issue described [here](https://bitbucket.org/hpk42/tox/issue/150/posargs-configerror) talons tox tests won't run with latest release of tox (1.7.1). To keep tests running we must use older version of tox where `{posargs}` replacement works as it should work. This isssue is already resolved but we must wait until new version of tox get released.
