### PR TITLE
Fix Issue #29 - Handle http_auth of None

### DIFF
--- a/talons/auth/basicauth.py
+++ b/talons/auth/basicauth.py
@@ -43,6 +43,8 @@ class Identifier(interfaces.Identifies):
             return True
 
         http_auth = request.auth
+        if http_auth is None:
+            return False
 
         if isinstance(http_auth, six.string_types):
             http_auth = http_auth.encode('ascii')


### PR DESCRIPTION
talons.auth.basicauth.Identifier.identify() was not properly checking
for cases when falcon.request.Request.auth was None and not the expected
tuple of (auth_type, user_and_key). We patch up the identifier to handle
None and add a unit test to prevent regressions.

Closes Issue #29 
