### PR TITLE
Fix up tests.auth.test_basicauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ channel. Interested in improving and enhancing Talons? Pull requests are always 
 
 ## License and Copyright
 
-Copyright 2013, Jay Pipes
+Copyright 2013-2014, Jay Pipes
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Noticed that there were calls to mock.MagicMock.assert_not_called(),
which isn't an actual method and needed to be
self.assertFalse(mock.called). While in there, cleaned up the mocking
out of properties and removed the mock.patch as a context manager,
instead using the decorator on the class itself instead.
